### PR TITLE
Send only drawing lines updates

### DIFF
--- a/src/games/kalambury/Board/GameBoard.js
+++ b/src/games/kalambury/Board/GameBoard.js
@@ -39,6 +39,28 @@ const GameBoard = ({ guess, setGuess, envokeLastAnswer, guessInputRef }) => {
     [sendChatMessage]
   );
 
+  const updateLines = useCallback(
+    (type, data = null) => {
+      setLines((lines) => {
+        if (type === "add" && lines) {
+          return [...lines, data];
+        }
+        if (type === "append" && lines.length > 0) {
+          const last = lines[lines.length - 1];
+          return [...lines.slice(0, -1), { ...last, points: [...last.points, ...data] }];
+        }
+        if (type === "delete" && lines.length > 0) {
+          return lines.slice(0, -1);
+        }
+        if (type === "replace" && data) {
+          return data;
+        }
+        return lines;
+      });
+    },
+    [setLines]
+  );
+
   // send full drawing every 1sec
   useEffect(() => {
     if (isDrawing) {
@@ -72,28 +94,6 @@ const GameBoard = ({ guess, setGuess, envokeLastAnswer, guessInputRef }) => {
       setLines([]);
     }
   }, [isDrawing, phrase]);
-
-  const updateLines = useCallback(
-    (type, data = null) => {
-      setLines((lines) => {
-        if (type === "add" && lines) {
-          return [...lines, data];
-        }
-        if (type === "append" && lines.length > 0) {
-          const last = lines[lines.length - 1];
-          return [...lines.slice(0, -1), { ...last, points: [...last.points, ...data] }];
-        }
-        if (type === "delete" && lines.length > 0) {
-          return lines.slice(0, -1);
-        }
-        if (type === "replace" && data) {
-          return data;
-        }
-        return lines;
-      });
-    },
-    [setLines]
-  );
 
   useEffect(() => {
     if (isDrawing || chatMessages.length <= 0) return;

--- a/src/games/kalambury/Board/GameBoard.js
+++ b/src/games/kalambury/Board/GameBoard.js
@@ -31,7 +31,7 @@ const GameBoard = ({ guess, setGuess, envokeLastAnswer, guessInputRef }) => {
 
   const throttledSendAppend = useMemo(
     () =>
-      throttleAccumulate(sendChatMessage, 200, ([acc], [args]) => [
+      throttleAccumulate(sendChatMessage, 50, ([acc], [args]) => [
         {
           type: acc.type,
           data: [...acc.data, ...args.data],

--- a/src/games/kalambury/Board/GameBoard.js
+++ b/src/games/kalambury/Board/GameBoard.js
@@ -73,16 +73,6 @@ const GameBoard = ({ guess, setGuess, envokeLastAnswer, guessInputRef }) => {
     }
   }, [isDrawing, phrase]);
 
-  useEffect(() => {
-    if (isDrawing || chatMessages.length <= 0) return;
-    const lastMessage = chatMessages[chatMessages.length - 1].payload;
-
-    if (lastMessage.type && lastMessage.type.startsWith("UpdateDrawing")) {
-      const updateType = lastMessage.type.split(":")[1];
-      updateLines(updateType, lastMessage.data);
-    }
-  }, [isDrawing, chatMessages, updateLines]);
-
   const updateLines = useCallback(
     (type, data = null) => {
       setLines((lines) => {
@@ -104,6 +94,16 @@ const GameBoard = ({ guess, setGuess, envokeLastAnswer, guessInputRef }) => {
     },
     [setLines]
   );
+
+  useEffect(() => {
+    if (isDrawing || chatMessages.length <= 0) return;
+    const lastMessage = chatMessages[chatMessages.length - 1].payload;
+
+    if (lastMessage.type && lastMessage.type.startsWith("UpdateDrawing")) {
+      const updateType = lastMessage.type.split(":")[1];
+      updateLines(updateType, lastMessage.data);
+    }
+  }, [isDrawing, chatMessages, updateLines]);
 
   const handleLinesUpdate = useCallback(
     (type, data) => {

--- a/src/games/kalambury/DrawArea.js
+++ b/src/games/kalambury/DrawArea.js
@@ -4,13 +4,14 @@ import { LineType } from "config/propTypes";
 import { useBoardGame } from "contexts/BoardGameContext";
 import Drawing from "./Drawing";
 import Toolbar from "./Toolbar";
+import { UpdateTypes } from "./utils/update_lines";
 
 const propTypes = {
   lines: arrayOf(LineType).isRequired,
-  updateLines: func.isRequired,
+  onLinesUpdate: func.isRequired,
 };
 
-const DrawArea = ({ lines, updateLines }) => {
+const DrawArea = ({ lines, onLinesUpdate }) => {
   const [isDrawing, setIsDrawing] = useState(false);
   const [penColor, setPenColor] = useState("#1b1c1d");
   const [penSize, setPenSize] = useState(3);
@@ -35,9 +36,9 @@ const DrawArea = ({ lines, updateLines }) => {
   const addPointFromEvent = (event, addLine = false) => {
     const point = relativeCoordsForEvent(event);
     if (addLine) {
-      updateLines("add", { points: [point], color: penColor, width: penSize });
+      onLinesUpdate(UpdateTypes.add, { points: [point], color: penColor, width: penSize });
     } else {
-      updateLines("append", [point]);
+      onLinesUpdate(UpdateTypes.append, [point]);
     }
   };
 
@@ -64,22 +65,22 @@ const DrawArea = ({ lines, updateLines }) => {
   };
 
   const handleUndo = useCallback(() => {
-    updateLines("delete");
-  }, [updateLines]);
+    onLinesUpdate(UpdateTypes.delete);
+  }, [onLinesUpdate]);
 
   const handleClearAll = useCallback(() => {
-    updateLines("replace", []);
-  }, [updateLines]);
+    onLinesUpdate(UpdateTypes.replace, []);
+  }, [onLinesUpdate]);
 
   const handlePhraseChange = useCallback(() => {
-    updateLines("replace", []);
+    onLinesUpdate(UpdateTypes.replace, []);
     ChangePhrase([]);
-  }, [updateLines, ChangePhrase]);
+  }, [onLinesUpdate, ChangePhrase]);
 
   const handleForfeit = useCallback(() => {
-    updateLines("replace", []);
+    onLinesUpdate(UpdateTypes.replace, []);
     Forfeit();
-  }, [updateLines, Forfeit]);
+  }, [onLinesUpdate, Forfeit]);
 
   return (
     <div>

--- a/src/games/kalambury/DrawArea.js
+++ b/src/games/kalambury/DrawArea.js
@@ -7,10 +7,10 @@ import Toolbar from "./Toolbar";
 
 const propTypes = {
   lines: arrayOf(LineType).isRequired,
-  setLines: func.isRequired,
+  updateLines: func.isRequired,
 };
 
-const DrawArea = ({ lines, setLines }) => {
+const DrawArea = ({ lines, updateLines }) => {
   const [isDrawing, setIsDrawing] = useState(false);
   const [penColor, setPenColor] = useState("#1b1c1d");
   const [penSize, setPenSize] = useState(3);
@@ -19,12 +19,9 @@ const DrawArea = ({ lines, setLines }) => {
     moves: { Forfeit, ChangePhrase },
   } = useBoardGame();
 
-  const handleMouseUp = useCallback(
-    (e) => {
-      setIsDrawing(false);
-    },
-    [setIsDrawing]
-  );
+  const handleMouseUp = useCallback(() => {
+    setIsDrawing(false);
+  }, [setIsDrawing]);
 
   useEffect(() => {
     document.addEventListener("mouseup", handleMouseUp);
@@ -37,10 +34,11 @@ const DrawArea = ({ lines, setLines }) => {
 
   const addPointFromEvent = (event, addLine = false) => {
     const point = relativeCoordsForEvent(event);
-    const newLines = [...lines];
-    if (addLine) newLines.push({ points: [], color: penColor, width: penSize });
-    newLines[newLines.length - 1].points.push(point);
-    setLines(newLines);
+    if (addLine) {
+      updateLines("add", { points: [point], color: penColor, width: penSize });
+    } else {
+      updateLines("append", [point]);
+    }
   };
 
   const relativeCoordsForEvent = ({ currentTarget, clientX, clientY, touches }) => {
@@ -65,23 +63,23 @@ const DrawArea = ({ lines, setLines }) => {
     }
   };
 
-  const handleClearAll = useCallback(() => {
-    setLines([]);
-  }, [setLines]);
-
   const handleUndo = useCallback(() => {
-    setLines((lines) => lines.slice(0, -1));
-  }, [setLines]);
+    updateLines("delete");
+  }, [updateLines]);
+
+  const handleClearAll = useCallback(() => {
+    updateLines("replace", []);
+  }, [updateLines]);
 
   const handlePhraseChange = useCallback(() => {
+    updateLines("replace", []);
     ChangePhrase([]);
-    setLines([]);
-  }, [setLines, ChangePhrase]);
+  }, [updateLines, ChangePhrase]);
 
   const handleForfeit = useCallback(() => {
-    setLines([]);
+    updateLines("replace", []);
     Forfeit();
-  }, [setLines, Forfeit]);
+  }, [updateLines, Forfeit]);
 
   return (
     <div>

--- a/src/games/kalambury/DrawArea.stories.js
+++ b/src/games/kalambury/DrawArea.stories.js
@@ -12,10 +12,4 @@ export default {
   decorators: [kalamburyDecorator],
 };
 
-export const Default = () => (
-  <DrawArea
-    lines={lines}
-    setLines={action("setLines")}
-    remainingSeconds={number("remainingSeconds", 40)}
-  />
-);
+export const Default = () => <DrawArea lines={lines} updateLines={action("updateLines")} />;

--- a/src/games/kalambury/DrawArea.stories.js
+++ b/src/games/kalambury/DrawArea.stories.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { number } from "@storybook/addon-knobs";
 import lines from "games/kalambury/data/stories/lines";
 import { kalamburyDecorator } from "./GameContextMock";
 import DrawArea from "./DrawArea";

--- a/src/games/kalambury/Game.js
+++ b/src/games/kalambury/Game.js
@@ -194,7 +194,10 @@ export const Kalambury = {
                 move: Forfeit,
                 client: false,
               },
-              NotifyTimeout,
+              NotifyTimeout: {
+                move: NotifyTimeout,
+                ignoreStaleStateID: true,
+              },
               UpdateConnectedPlayers: {
                 move: UpdateConnectedPlayers,
                 ignoreStaleStateID: true,

--- a/src/games/kalambury/utils/update_lines.js
+++ b/src/games/kalambury/utils/update_lines.js
@@ -1,0 +1,22 @@
+export const UpdateTypes = {
+  add: "add",
+  append: "append",
+  delete: "delete",
+  replace: "replace",
+};
+
+export function updateLines(lines, updateType, updateData = null) {
+  switch (updateType) {
+    case UpdateTypes.add:
+      return [...lines, updateData];
+    case UpdateTypes.append:
+      const last = lines[lines.length - 1];
+      return [...lines.slice(0, -1), { ...last, points: [...last.points, ...updateData] }];
+    case UpdateTypes.delete:
+      return lines.slice(0, -1);
+    case UpdateTypes.replace:
+      return updateType;
+    default:
+      return lines;
+  }
+}

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,0 +1,23 @@
+import { throttle } from "lodash";
+
+export function throttleAccumulate(func, wait, accFunc) {
+  let accumulatedArgs = null;
+
+  const throttled = throttle((...args) => {
+    accumulatedArgs = null;
+    func(...args);
+  }, wait);
+
+  const resultFunc = (...args) => {
+    if (accumulatedArgs == null) {
+      accumulatedArgs = args;
+    } else {
+      accumulatedArgs = accFunc(accumulatedArgs, args);
+    }
+    throttled(...accumulatedArgs);
+  };
+  resultFunc.flush = () => throttled.flush();
+  return resultFunc;
+}
+
+window.throttleAccumulate = throttleAccumulate;


### PR DESCRIPTION
Improve Kalambury performance by sending less drawing data.

- [x] send only incremental updates of lines
- [x] throttle request so we don't send updates on every mousemove (max 5RPS)
- [x] make sure newly connected players get full drawing update from time to time (every 1 sec) 