### PR TITLE
Update caching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,3 +17,10 @@
     max-age=31536000,
     public,
     immutable'''
+[[headers]]
+  for = "/locales/*"
+  [headers.values]
+    cache-control = '''
+    max-age=3600,
+    public,
+    must-revalidate'''

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,10 @@
     max-age=2592000,
     public,
     immutable'''
+[[headers]]
+  for = "/static/*"
+  [headers.values]
+    cache-control = '''
+    max-age=31536000,
+    public,
+    immutable'''

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,10 @@
   to = "/index.html"
   status = 200
   force = false
+[[headers]]
+  for = "/images/*"
+  [headers.values]
+    cache-control = '''
+    max-age=2592000,
+    public,
+    immutable'''


### PR DESCRIPTION
Fixes: #204 
With better cache control we can improve app performance slightly:
- images can be cached for a long time (30 days) as we don't usually change them
- static files can be cached pretty much forever (1 year) because they have hashed names, so any change in file would give a new filename
- locales should be cached, so we don't fetch them on every page view, but they have static filenames, so we'll only cache them for a short duration (1 hour)